### PR TITLE
Add Papercups Chat Widget

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ require("@rails/activestorage").start()
 require("channels")
 
 require('dropzone')
+require('papercup')
 
 import 'bootstrap'
 import '../stylesheets/bootstrap_extensions'

--- a/app/javascript/papercup.js
+++ b/app/javascript/papercup.js
@@ -1,0 +1,9 @@
+window.Papercups = {
+  config: {
+    accountId: "c8e2f62e-15b1-4399-b6d5-44efdbd272be",
+    title: "Welcome to USDR",
+    subtitle: "Ask us anything in the chat window below :blush:",
+    primaryColor: "#1890FF",
+    baseUrl: "https://app.papercups.io"
+  },
+};

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,6 +11,7 @@
     = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     %script{src: 'https://kit.fontawesome.com/e9501c4774.js', crossorigin: 'anonymous'}
+    %script{async: true, src: 'https://app.papercups.io/widget.js'}
   %body
     .warning
       .container= t('shared.demo_banner')


### PR DESCRIPTION
[#174103372]

### Motivation
We want a chat widget present on the demo so that users can submit questions and receive answers. This PR adds the [Papercups](https://papercups.io/) script to the applications. 

### Changes
1. Adds a new `papercup.js` configuration file, which is used to configure the appearance of the widget and use our specific account id
1. Wires up the above in the `application.js` file
1. Adds the `papercup` script to the application `html.haml` file

<img width="950" alt="Image 2020-08-17 at 7 12 36 PM" src="https://user-images.githubusercontent.com/5530093/90453261-2e18b280-e0be-11ea-8548-04b98e25a27e.png">
<img width="474" alt="Image 2020-08-17 at 7 12 47 PM" src="https://user-images.githubusercontent.com/5530093/90453267-3113a300-e0be-11ea-890e-5737ae84784f.png">
