### PR TITLE
174105084 history

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.1'
 
 gem 'alloy-api', '>= 0.0.7'
+gem 'audited', '~> 4.9'
 gem 'aws-sdk-s3'
 gem 'bcrypt', '~> 3.1.13'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
     alloy-api (0.0.7)
       httparty (~> 0.18)
     ast (2.4.1)
+    audited (4.9.0)
+      activerecord (>= 4.2, < 6.1)
     aws-eventstream (1.1.0)
     aws-partitions (1.336.0)
     aws-sdk-core (3.102.1)
@@ -284,6 +286,7 @@ PLATFORMS
 
 DEPENDENCIES
   alloy-api (>= 0.0.7)
+  audited (~> 4.9)
   aws-sdk-s3
   bcrypt (~> 3.1.13)
   bootsnap (>= 1.4.2)

--- a/app/controllers/admin/applicants_controller.rb
+++ b/app/controllers/admin/applicants_controller.rb
@@ -35,6 +35,7 @@ class Admin::ApplicantsController < Admin::AdminController
 
   def set_applicant
     @applicant = Applicant.includes(:line_item_decisions).find(params[:id])
+    @audits = @applicant.audits
   end
 
   def search

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -27,6 +27,8 @@ class Applicant < ApplicationRecord
     closed: 4
   }
 
+  audited
+
   after_create_commit :make_descision, unless: -> { disable_verification }
 
   scope :for_current_workflow, -> { where(application_token: Rails.application.credentials.alloy[:token]) }

--- a/app/views/admin/applicants/_applicant_history.html.haml
+++ b/app/views/admin/applicants/_applicant_history.html.haml
@@ -1,0 +1,25 @@
+#APPLICANT_HISTORY_MODAL.modal.fade{tabindex: '-1', role: 'dialog', aria: {labelledby: '#APPLICANT_HISTORY_MODAL_LABEL', hidden: 'true'}}
+  .modal-dialog.modal-lg
+    .modal-content
+      .modal-header
+        %h5#APPLICANT_HISTORY_MODAL.modal-title= t('claim.history.title')
+        %button.close{type: 'button', data: {dismiss: 'modal'}, aria: {label: 'Close'}}
+          %i.fas.fa-times
+      .modal-body
+        = t('claim.history.overview')
+        %table
+          %thead
+            %tr
+              %th= t('claim.history.date')
+              %th= t('claim.history.user')
+              %th= t('claim.personal.type')
+              %th= t('claim.personal.changes')
+            %tbody
+              - @audits.each do |audit|
+                %tr
+                  %td= audit.created_at.to_datetime.strftime('%F %T')
+                  %td= 'Someone'
+                  %td= audit.action
+                  %td
+                    - audit.audited_changes.keys.each do |change|
+                      = change + " changed from " + audit.audited_changes.fetch(change)[0].to_s + " to " + audit.audited_changes.fetch(change)[1].to_s

--- a/app/views/admin/applicants/show.html.haml
+++ b/app/views/admin/applicants/show.html.haml
@@ -38,7 +38,8 @@
             %span.badge.status-pending= t('claim.statuses.pending')
           =t('claim.filed_on', date: @applicant.created_at&.iso8601)
       .actions
-        = link_to '#' do
+        = render 'applicant_history'
+        = link_to '#', data: {toggle: 'modal', target: '#APPLICANT_HISTORY_MODAL'} do
           = fa_icon :history
           = t('claim.actions.hx')
         = link_to t('claim.actions.update'), '#', class: 'btn btn-primary btn-lg', data: {toggle: :modal, target: '#UPDATE_DIALOG'}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,12 @@ en:
       review: Review
       closed: Closed
       pending: Pending
+    history:
+      date: Date
+      changes: Changes
+      user: Modified By
+      overview: This modal displays changes made to this claim.
+      title: Claim History
     alerts:
       unverified: This claim is pending because some information could not be verified. Click on unverified data to see why.
     sections:

--- a/db/migrate/20200829150210_install_audited.rb
+++ b/db/migrate/20200829150210_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :text
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index'
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_27_013318) do
+ActiveRecord::Schema.define(version: 2020_08_29_150210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -65,6 +65,29 @@ ActiveRecord::Schema.define(version: 2020_08_27_013318) do
     t.string "application_token"
     t.string "application_version_id"
     t.integer "processing_status", default: 0, null: false
+    t.integer "status", default: 1, null: false
+  end
+
+  create_table "audits", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.text "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "bank_accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Adds audit. It's not the cleanest implementation so looking for feedback on how to best do it.

Some things that I know are problems that I need to address but unsure about are..
- [x] Why is ```@revisions``` content automatically rendered before the tbody
- [ ] Fetch Revision information only when modal is opened.
- [x] Make history table body relevant. (Only track things showing up there, or give a way to show all possible changes)

The blob of text above is the representation of the revision data, not sure why it's rendering. :(
![image](https://user-images.githubusercontent.com/1707315/91100389-1ea3e700-e633-11ea-9320-5fd169d5aeff.png)
