### PR TITLE
Attempting to unbreak audit display

### DIFF
--- a/app/views/admin/applicants/_applicant_history.html.haml
+++ b/app/views/admin/applicants/_applicant_history.html.haml
@@ -21,5 +21,5 @@
                   %td= 'Someone'
                   %td= audit.action
                   %td
-                    - audit.audited_changes.keys.each do |change|
-                      = change + " changed from " + audit.audited_changes.fetch(change)[0].to_s + " to " + audit.audited_changes.fetch(change)[1].to_s
+                    / - audit.audited_changes.keys.each do |change|
+                    /   = change + " changed from " + audit.audited_changes.fetch(change)[0].to_s + " to " + audit.audited_changes.fetch(change)[1].to_s


### PR DESCRIPTION
Something about displaying audits is breaking rendering- not all audited changes have a [0] and [1].  I'm not sure why- maybe when a field is newly set, it doesn't have a "previous" value?

In any case, commenting out the problematic code just to get things working, as discussed at https://app.slack.com/client/TVDP74XAM/C01874U5PDH/thread/C01874U5PDH-1599080600.052500