### PR TITLE
Handle "initial" audits, which don't have prev value

### DIFF
--- a/app/views/admin/applicants/_applicant_history.html.haml
+++ b/app/views/admin/applicants/_applicant_history.html.haml
@@ -21,5 +21,9 @@
                   %td= 'Someone'
                   %td= audit.action
                   %td
-                    / - audit.audited_changes.keys.each do |change|
-                    /   = change + " changed from " + audit.audited_changes.fetch(change)[0].to_s + " to " + audit.audited_changes.fetch(change)[1].to_s
+                    - audit.audited_changes.keys.each do |change|
+                      - audited_change = audit.audited_changes.fetch(change)
+                      - if audited_change.kind_of?(Array)
+                        = change + " changed from " + audited_change[0].to_s + " to " + audited_change[1].to_s
+                      - else
+                        = change + " initialized to " + audited_change.to_s


### PR DESCRIPTION
A more complete fix for https://github.com/usdigitalresponse/papua-id-demo/pull/33.  It appears that there are (at least) two types of audits.  A typical audit records a before and after value for an attribute.  But when the object is new, it doesn't have a before value, so the audit just records the after value.  The audit is either an array of [before_value, after_value], or is just the after_value.