### PR TITLE
174612829: Left justify claim details

### DIFF
--- a/app/javascript/stylesheets/admin/claims.scss
+++ b/app/javascript/stylesheets/admin/claims.scss
@@ -107,6 +107,7 @@ ul.filters {
         line-height: 21px;
         dt {
           font-weight: normal;
+          min-width: 200px;
         }
         dd {
           font-weight: bold;
@@ -129,7 +130,7 @@ ul.filters {
         .dl-row {
           @extend .d-flex;
           @extend .flex-row;
-          @extend .justify-content-between;
+          @extend .justify-content-start;
           @extend .py-3;
           border-top: 1px solid $gray-200;
         }


### PR DESCRIPTION
See https://www.pivotaltracker.com/n/projects/2459634/stories/174612829 and Figma https://www.figma.com/file/yJiEWTit2m64e0XMnBWJue/UIM-App?node-id=356%3A979

Before:

![before](https://user-images.githubusercontent.com/6463731/92138179-e898fc80-edc2-11ea-8b25-09742343a70f.png)

After:

![after](https://user-images.githubusercontent.com/6463731/92138196-ed5db080-edc2-11ea-8031-a6d1d987cb86.png)


NOTE: This is not a great solution, since it uses "min-width" on the first column to buffer out the second column.  This isn't reactive (won't look great on small screens, since there might be a lot of wasted space), and may look funny when the first column has long text (greater than 200 px.)  I spent a fair amount of time playing with flex layouts to try to get the rows/columns to lay out in a gridlike manner, but wasn't able to figure out how to use flex to get the width of the first column to be consistent across rows, etc.  My expertise in flex, and in CSS in general, is very low, so there may well be an easy way to do it without changing the HTML layout, but I didn't immediately see it.

