### PR TITLE
smedberg/174720792: Verification framework

### DIFF
--- a/app/jobs/true_work_wage_validation_job.rb
+++ b/app/jobs/true_work_wage_validation_job.rb
@@ -1,0 +1,8 @@
+class TrueWorkWageValidationJob < ApplicationJob
+  queue_as :default
+
+  def perform(validation_id)
+    validation = TrueWorkWageValidation.find(validation_id)
+    validation.validate
+  end
+end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -4,6 +4,7 @@ class Applicant < ApplicationRecord
   has_one :wage_verification, dependent: :destroy
   has_many :line_item_decisions, as: :decidable, dependent: :destroy
   has_many :tasks, dependent: :destroy
+  has_many :validations, dependent: :destroy
 
   attr_accessor :disable_verification
 

--- a/app/models/true_work_wage_validation.rb
+++ b/app/models/true_work_wage_validation.rb
@@ -1,0 +1,14 @@
+class TrueWorkWageValidation < WageValidation
+
+  def self.job_class
+  	TrueWorkWageValidationJob
+  end
+
+  def validate
+  	self.update_attributes(status: :in_process)
+  	# TODO: Get TrueWorks API endpoint wrapper
+  	# Call API (remember to handle timeouts, errors, etc.)
+  	# Use info in self.input to know what to pass to TrueWorks
+  	self.update_attributes(status: :complete, decision: :approved)
+  end
+end

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -1,0 +1,19 @@
+class Validation < ApplicationRecord
+  belongs_to :applicant
+
+  enum status: [ :started, :in_process, :complete, :error ]
+  enum decision: [ :approved, :denied]
+
+  # NOTE: Do not call `validate_applicant` in superclass.  Instead, call in subclass, like
+  # TrueWorkWageValidation.validate_applicant
+  def self.validate_applicant(applicant, input)
+  	validation = self.new
+  	validation.applicant = applicant
+  	validation.input = input
+  	validation.status = :started
+  	validation.save!
+  	self.job_class.set(wait: 1.second).perform_later(validation.id)
+
+  	validation
+  end
+end

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -1,8 +1,8 @@
 class Validation < ApplicationRecord
   belongs_to :applicant
 
-  enum status: [ :started, :in_process, :complete, :error ]
-  enum decision: [ :approved, :denied]
+  enum status: { started: 0, in_process: 1, complete: 2, error: 3 }
+  enum decision: { approved: 0, denied: 1 }
 
   # NOTE: Do not call `validate_applicant` in superclass.  Instead, call in subclass, like
   # TrueWorkWageValidation.validate_applicant

--- a/app/models/wage_validation.rb
+++ b/app/models/wage_validation.rb
@@ -1,0 +1,2 @@
+class WageValidation < Validation
+end

--- a/db/migrate/20200909183314_create_validation.rb
+++ b/db/migrate/20200909183314_create_validation.rb
@@ -1,0 +1,12 @@
+class CreateValidation < ActiveRecord::Migration[6.0]
+  def change
+    create_table :validations, id: :uuid do |t|
+      t.references :applicant, type: :uuid, null: false
+      t.string :type, null: false
+      t.jsonb :input
+      t.jsonb :output
+      t.integer :status, default: 0, null: false
+      t.integer :decision
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_09_143353) do
+ActiveRecord::Schema.define(version: 2020_09_09_183314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -143,6 +143,16 @@ ActiveRecord::Schema.define(version: 2020_09_09_143353) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "validations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "applicant_id", null: false
+    t.string "type", null: false
+    t.jsonb "input"
+    t.jsonb "output"
+    t.integer "status", default: 0, null: false
+    t.integer "decision"
+    t.index ["applicant_id"], name: "index_validations_on_applicant_id"
   end
 
   create_table "wage_verifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
As discussed with Matthew, this is a first cut at making a more generic framework for validations.  There's a superclass called `Validation`, with a subclass called `TrueWorkWageValidation`.  `Validation` implements `validate_applicant`, which will create an instance of the relevant subclass, set the initial conditions, and enqueue an asynchronous job to perform the validation.

Here's an example of calling it:
```
rails c
TrueWorkWageValidation.validate_applicant(Applicant.first, {foo: 'bar'})
```
which results in:
```
select * from validations;

                  id                  |             applicant_id             |          type          |     input      | output | status | decision
--------------------------------------+--------------------------------------+------------------------+----------------+--------+--------+----------
 fc1600d6-2728-4b0e-9f63-0d3342fb7488 | 01110aa3-73af-4ddb-beef-68a24e637c45 | TrueWorkWageValidation | {"foo": "bar"} |        |      2 |        0
(1 row)
```