### PR TITLE
Fix broken asset fetching

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,6 @@ module Papua
       g.fixtures        false
     end
 
-    config.x.truework_demo  = false
+    config.x.truework_demo  = true
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,6 @@ module Papua
       g.fixtures        false
     end
 
-    config.x.truework_demo  = true
+    config.x.truework_demo  = false
   end
 end

--- a/config/initializers/webmock.rb
+++ b/config/initializers/webmock.rb
@@ -13,7 +13,7 @@ if Rails.configuration.x.truework_demo
 	require 'webmock'
 	include WebMock::API
 	WebMock.enable!
-	WebMock.allow_net_connect!
+	WebMock.allow_net_connect!(net_http_connect_on_start: true)
 
 	# From https://raw.githubusercontent.com/truework/truework-sdk-ruby/d2c69df3752f31a4fa0b89e6588d8f55ee94809d/spec/fixtures/report/report_1.json
 	verification_1_status = {


### PR DESCRIPTION
When using Webmock with `Net::HTTP`, we need to pass `net_http_connect_on_start: true` into `WebMock.allow_net_connect!` as documented at https://github.com/bblimke/webmock#connecting-on-nethttpstart